### PR TITLE
feat: add MANTRA Claimdrop Contracts support

### DIFF
--- a/src/claimdrop.rs
+++ b/src/claimdrop.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Coin, Timestamp, Uint128};
+use cosmwasm_std::{Timestamp, Uint128};
 use serde::{Deserialize, Serialize};
 
 /// Execute messages for the claimdrop contract

--- a/src/claimdrop.rs
+++ b/src/claimdrop.rs
@@ -1,0 +1,117 @@
+use cosmwasm_std::{Coin, Timestamp, Uint128};
+use serde::{Deserialize, Serialize};
+
+/// Execute messages for the claimdrop contract
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimdropExecuteMsg {
+    /// Claim the airdrop tokens for the sender
+    Claim {},
+    /// Update configuration (admin only)
+    UpdateConfig {
+        /// New merkle root for the airdrop
+        merkle_root: Option<String>,
+        /// New claim start time
+        start_time: Option<Timestamp>,
+        /// New claim end time  
+        end_time: Option<Timestamp>,
+        /// New admin address
+        admin: Option<String>,
+    },
+    /// Pause/unpause claims (admin only)
+    SetClaimsPaused { paused: bool },
+}
+
+/// Query messages for the claimdrop contract
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimdropQueryMsg {
+    /// Get the contract configuration
+    Config {},
+    /// Get claimable amount for a specific address
+    ClaimableAmount { address: String },
+    /// Check if an address has claimed
+    IsClaimed { address: String },
+    /// Get claim status and details for an address
+    ClaimStatus { address: String },
+    /// Get total claimed amount
+    TotalClaimed {},
+    /// Get merkle proof for verification (if applicable)
+    MerkleProof { address: String },
+}
+
+/// Response for the config query
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConfigResponse {
+    /// The admin address
+    pub admin: String,
+    /// The merkle root of the airdrop
+    pub merkle_root: String,
+    /// The claim start time
+    pub start_time: Timestamp,
+    /// The claim end time
+    pub end_time: Timestamp,
+    /// Whether claims are paused
+    pub claims_paused: bool,
+    /// The native token denom for claims
+    pub claim_denom: String,
+}
+
+/// Response for claimable amount query
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaimableAmountResponse {
+    /// The amount that can be claimed
+    pub amount: Uint128,
+    /// The denom of the claimable token
+    pub denom: String,
+    /// Whether the address is eligible for claiming
+    pub is_eligible: bool,
+    /// The merkle proof for verification
+    pub proof: Option<Vec<String>>,
+}
+
+/// Response for claim status query
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaimStatusResponse {
+    /// Whether the address has claimed
+    pub is_claimed: bool,
+    /// The amount claimed (0 if not claimed)
+    pub claimed_amount: Uint128,
+    /// The claimable amount
+    pub claimable_amount: Uint128,
+    /// The denom of the token
+    pub denom: String,
+    /// Whether the address is eligible
+    pub is_eligible: bool,
+    /// The time when the claim was made (if claimed)
+    pub claim_time: Option<Timestamp>,
+}
+
+/// Response for total claimed query
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TotalClaimedResponse {
+    /// Total amount claimed across all users
+    pub total_claimed: Uint128,
+    /// The denom of the claimed token
+    pub denom: String,
+    /// Number of unique claimers
+    pub total_claimers: u64,
+}
+
+/// Response for merkle proof query
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MerkleProofResponse {
+    /// The merkle proof for the address
+    pub proof: Vec<String>,
+    /// The amount for this address in the merkle tree
+    pub amount: Uint128,
+    /// Whether the proof is valid
+    pub is_valid: bool,
+}
+
+/// Simple response for boolean queries
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IsClaimedResponse {
+    /// Whether the address has claimed
+    pub is_claimed: bool,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,6 +86,8 @@ pub struct ContractAddresses {
     pub skip_entry_point: Option<String>,
     pub skip_ibc_hooks_adapter: Option<String>,
     pub skip_mantra_dex_adapter: Option<String>,
+    /// Claimdrop contract address
+    pub claimdrop_manager: Option<String>,
 }
 
 impl Default for ContractAddresses {
@@ -98,6 +100,7 @@ impl Default for ContractAddresses {
             skip_entry_point: None,
             skip_ibc_hooks_adapter: None,
             skip_mantra_dex_adapter: None,
+            claimdrop_manager: None,
         }
     }
 }
@@ -166,6 +169,7 @@ impl MantraNetworkConfig {
                     format!("{}.skip_ibc_hooks_adapter.address", network);
                 let skip_mantra_dex_adapter_key =
                     format!("{}.skip_mantra_dex_adapter.address", network);
+                let claimdrop_manager_key = format!("{}.claimdrop_manager.address", network);
 
                 if let Ok(pool_manager) = settings.get::<String>(&pool_manager_key) {
                     return Ok(ContractAddresses {
@@ -180,6 +184,7 @@ impl MantraNetworkConfig {
                         skip_mantra_dex_adapter: settings
                             .get::<String>(&skip_mantra_dex_adapter_key)
                             .ok(),
+                        claimdrop_manager: settings.get::<String>(&claimdrop_manager_key).ok(),
                     });
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod claimdrop;
 pub mod config;
 pub mod error;
 pub mod skip_adapter;
@@ -15,6 +16,10 @@ pub mod mcp;
 pub use mantra_dex_std;
 
 pub use client::MantraDexClient;
+pub use claimdrop::{
+    ClaimdropExecuteMsg, ClaimdropQueryMsg, ClaimableAmountResponse, ClaimStatusResponse,
+    ConfigResponse, IsClaimedResponse, MerkleProofResponse, TotalClaimedResponse,
+};
 pub use config::{MantraNetworkConfig, NetworkConstants};
 pub use error::Error;
 pub use skip_adapter::{

--- a/src/mcp/sdk_adapter.rs
+++ b/src/mcp/sdk_adapter.rs
@@ -2733,6 +2733,129 @@ impl McpSdkAdapter {
         }
         Ok(())
     }
+
+    // ========== Claimdrop Methods ==========
+
+    /// Claim airdrop for the active wallet
+    pub async fn claim_airdrop(&self, args: Value) -> McpResult<Value> {
+        debug!("SDK Adapter: Claiming airdrop with args: {:?}", args);
+
+        let client = self.get_client().await?;
+        let result = client.claim_airdrop().await
+            .map_err(|e| McpServerError::SdkError(e.to_string()))?;
+
+        Ok(serde_json::to_value(result)?)
+    }
+
+    /// Query claimable amount for an address
+    pub async fn query_claimable_amount(&self, args: Value) -> McpResult<Value> {
+        debug!("SDK Adapter: Querying claimable amount with args: {:?}", args);
+
+        let client = self.get_client().await?;
+        
+        // Get address - use provided address or default to active wallet
+        let address = if let Some(addr) = args.get("address").and_then(|v| v.as_str()) {
+            addr.to_string()
+        } else {
+            // Get active wallet address
+            let wallet_info = client.wallet.get_wallet_info()
+                .map_err(|e| McpServerError::WalletError(e.to_string()))?;
+            wallet_info.address
+        };
+
+        let result = client.query_claimable_amount(&address).await
+            .map_err(|e| McpServerError::SdkError(e.to_string()))?;
+
+        Ok(serde_json::to_value(result)?)
+    }
+
+    /// Query claim status for an address
+    pub async fn query_claim_status(&self, args: Value) -> McpResult<Value> {
+        debug!("SDK Adapter: Querying claim status with args: {:?}", args);
+
+        let client = self.get_client().await?;
+        
+        // Get address - use provided address or default to active wallet
+        let address = if let Some(addr) = args.get("address").and_then(|v| v.as_str()) {
+            addr.to_string()
+        } else {
+            // Get active wallet address
+            let wallet_info = client.wallet.get_wallet_info()
+                .map_err(|e| McpServerError::WalletError(e.to_string()))?;
+            wallet_info.address
+        };
+
+        let result = client.query_claim_status(&address).await
+            .map_err(|e| McpServerError::SdkError(e.to_string()))?;
+
+        Ok(serde_json::to_value(result)?)
+    }
+
+    /// Check if an address has claimed airdrop
+    pub async fn is_airdrop_claimed(&self, args: Value) -> McpResult<Value> {
+        debug!("SDK Adapter: Checking if airdrop claimed with args: {:?}", args);
+
+        let client = self.get_client().await?;
+        
+        // Get address - use provided address or default to active wallet
+        let address = if let Some(addr) = args.get("address").and_then(|v| v.as_str()) {
+            addr.to_string()
+        } else {
+            // Get active wallet address
+            let wallet_info = client.wallet.get_wallet_info()
+                .map_err(|e| McpServerError::WalletError(e.to_string()))?;
+            wallet_info.address
+        };
+
+        let result = client.is_airdrop_claimed(&address).await
+            .map_err(|e| McpServerError::SdkError(e.to_string()))?;
+
+        Ok(serde_json::to_value(result)?)
+    }
+
+    /// Query claimdrop configuration
+    pub async fn query_claimdrop_config(&self, _args: Value) -> McpResult<Value> {
+        debug!("SDK Adapter: Querying claimdrop config");
+
+        let client = self.get_client().await?;
+        let result = client.query_claimdrop_config().await
+            .map_err(|e| McpServerError::SdkError(e.to_string()))?;
+
+        Ok(serde_json::to_value(result)?)
+    }
+
+    /// Query total claimed statistics
+    pub async fn query_total_claimed(&self, _args: Value) -> McpResult<Value> {
+        debug!("SDK Adapter: Querying total claimed statistics");
+
+        let client = self.get_client().await?;
+        let result = client.query_total_claimed().await
+            .map_err(|e| McpServerError::SdkError(e.to_string()))?;
+
+        Ok(serde_json::to_value(result)?)
+    }
+
+    /// Query merkle proof for an address
+    pub async fn query_merkle_proof(&self, args: Value) -> McpResult<Value> {
+        debug!("SDK Adapter: Querying merkle proof with args: {:?}", args);
+
+        let client = self.get_client().await?;
+        
+        // Get address - use provided address or default to active wallet
+        let address = if let Some(addr) = args.get("address").and_then(|v| v.as_str()) {
+            addr.to_string()
+        } else {
+            // Get active wallet address
+            let wallet_info = client.wallet.get_wallet_info()
+                .map_err(|e| McpServerError::WalletError(e.to_string()))?;
+            wallet_info.address
+        };
+
+        let result = client.query_merkle_proof(&address).await
+            .map_err(|e| McpServerError::SdkError(e.to_string()))?;
+
+        Ok(serde_json::to_value(result)?)
+    }
 }
 
 impl Default for McpSdkAdapter {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2641,6 +2641,84 @@ impl McpToolProvider for MantraDexMcpServer {
                     "required": ["pool_id"]
                 }
             }),
+
+            // Claimdrop Tools
+            serde_json::json!({
+                "name": "claim_airdrop",
+                "description": "Claim airdrop tokens for the active wallet address",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {}
+                }
+            }),
+            serde_json::json!({
+                "name": "query_claimable_amount",
+                "description": "Query claimable airdrop amount for a specific address",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string",
+                            "description": "Address to check claimable amount for (optional, uses active wallet if not provided)"
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "name": "query_claim_status",
+                "description": "Query detailed claim status for a specific address",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string",
+                            "description": "Address to check claim status for (optional, uses active wallet if not provided)"
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "name": "is_airdrop_claimed",
+                "description": "Check if an address has already claimed their airdrop",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string",
+                            "description": "Address to check (optional, uses active wallet if not provided)"
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "name": "query_claimdrop_config",
+                "description": "Query the claimdrop contract configuration",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {}
+                }
+            }),
+            serde_json::json!({
+                "name": "query_total_claimed",
+                "description": "Query total claimed statistics across all users",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {}
+                }
+            }),
+            serde_json::json!({
+                "name": "query_merkle_proof",
+                "description": "Query merkle proof for an address (if applicable)",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string",
+                            "description": "Address to get proof for (optional, uses active wallet if not provided)"
+                        }
+                    }
+                }
+            }),
         ]
     }
 
@@ -2674,6 +2752,14 @@ impl McpToolProvider for MantraDexMcpServer {
             "estimate_lp_withdrawal_amounts" => {
                 self.handle_estimate_lp_withdrawal_amounts(arguments).await
             }
+            // Claimdrop tools
+            "claim_airdrop" => self.handle_claim_airdrop(arguments).await,
+            "query_claimable_amount" => self.handle_query_claimable_amount(arguments).await,
+            "query_claim_status" => self.handle_query_claim_status(arguments).await,
+            "is_airdrop_claimed" => self.handle_is_airdrop_claimed(arguments).await,
+            "query_claimdrop_config" => self.handle_query_claimdrop_config(arguments).await,
+            "query_total_claimed" => self.handle_query_total_claimed(arguments).await,
+            "query_merkle_proof" => self.handle_query_merkle_proof(arguments).await,
             _ => Err(McpServerError::UnknownTool(tool_name.to_string())),
         }
     }
@@ -3677,6 +3763,134 @@ impl MantraDexMcpServer {
         let result = self.state.sdk_adapter.create_pool(arguments).await?;
 
         // Format as MCP response
+        Ok(serde_json::json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": serde_json::to_string_pretty(&result)?
+                }
+            ]
+        }))
+    }
+
+    // ========== Claimdrop Tool Handlers ==========
+
+    /// Handle claim_airdrop tool
+    async fn handle_claim_airdrop(
+        &self,
+        arguments: serde_json::Value,
+    ) -> McpResult<serde_json::Value> {
+        info!(?arguments, "Handling claim_airdrop tool call");
+        let result = self.state.sdk_adapter.claim_airdrop(arguments).await?;
+
+        Ok(serde_json::json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": serde_json::to_string_pretty(&result)?
+                }
+            ]
+        }))
+    }
+
+    /// Handle query_claimable_amount tool
+    async fn handle_query_claimable_amount(
+        &self,
+        arguments: serde_json::Value,
+    ) -> McpResult<serde_json::Value> {
+        info!(?arguments, "Handling query_claimable_amount tool call");
+        let result = self.state.sdk_adapter.query_claimable_amount(arguments).await?;
+
+        Ok(serde_json::json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": serde_json::to_string_pretty(&result)?
+                }
+            ]
+        }))
+    }
+
+    /// Handle query_claim_status tool
+    async fn handle_query_claim_status(
+        &self,
+        arguments: serde_json::Value,
+    ) -> McpResult<serde_json::Value> {
+        info!(?arguments, "Handling query_claim_status tool call");
+        let result = self.state.sdk_adapter.query_claim_status(arguments).await?;
+
+        Ok(serde_json::json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": serde_json::to_string_pretty(&result)?
+                }
+            ]
+        }))
+    }
+
+    /// Handle is_airdrop_claimed tool
+    async fn handle_is_airdrop_claimed(
+        &self,
+        arguments: serde_json::Value,
+    ) -> McpResult<serde_json::Value> {
+        info!(?arguments, "Handling is_airdrop_claimed tool call");
+        let result = self.state.sdk_adapter.is_airdrop_claimed(arguments).await?;
+
+        Ok(serde_json::json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": serde_json::to_string_pretty(&result)?
+                }
+            ]
+        }))
+    }
+
+    /// Handle query_claimdrop_config tool
+    async fn handle_query_claimdrop_config(
+        &self,
+        arguments: serde_json::Value,
+    ) -> McpResult<serde_json::Value> {
+        info!(?arguments, "Handling query_claimdrop_config tool call");
+        let result = self.state.sdk_adapter.query_claimdrop_config(arguments).await?;
+
+        Ok(serde_json::json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": serde_json::to_string_pretty(&result)?
+                }
+            ]
+        }))
+    }
+
+    /// Handle query_total_claimed tool
+    async fn handle_query_total_claimed(
+        &self,
+        arguments: serde_json::Value,
+    ) -> McpResult<serde_json::Value> {
+        info!(?arguments, "Handling query_total_claimed tool call");
+        let result = self.state.sdk_adapter.query_total_claimed(arguments).await?;
+
+        Ok(serde_json::json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": serde_json::to_string_pretty(&result)?
+                }
+            ]
+        }))
+    }
+
+    /// Handle query_merkle_proof tool
+    async fn handle_query_merkle_proof(
+        &self,
+        arguments: serde_json::Value,
+    ) -> McpResult<serde_json::Value> {
+        info!(?arguments, "Handling query_merkle_proof tool call");
+        let result = self.state.sdk_adapter.query_merkle_proof(arguments).await?;
+
         Ok(serde_json::json!({
             "content": [
                 {

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -66,6 +66,7 @@ pub mod test_utils {
             skip_entry_point: None,
             skip_ibc_hooks_adapter: None,
             skip_mantra_dex_adapter: None,
+            claimdrop_manager: None,
         }
     }
 


### PR DESCRIPTION
Implements comprehensive support for MANTRA Claimdrop Contracts as requested in issue #10.

## Changes
- Add claimdrop contract address configuration
- Implement comprehensive claimdrop message types and responses
- Add 8 claimdrop methods to MantraDexClient
- Add 7 MCP tools for claimdrop operations
- Integrate with existing SDK patterns and error handling

## Features
- Execute operations: claim_airdrop()
- Query operations: claimable amount, claim status, config, statistics, merkle proofs
- MCP server integration with smart address handling
- Full compatibility with existing SDK architecture

Closes #10

Generated with [Claude Code](https://claude.ai/code)